### PR TITLE
Autofocus textCOE

### DIFF
--- a/src/components/content_object_renderers/TextCOE.tsx
+++ b/src/components/content_object_renderers/TextCOE.tsx
@@ -61,6 +61,7 @@ export default function TextCOE({ show, setShow, content }: TextCOEProps) {
                             onChange={(event: ChangeEvent<any>) => {
                                 setInternalText(event.target.value);
                             }}
+                            autoFocus
                         />
                     </Form.Group>
                     <Button type={'submit'} variant={'success'}>


### PR DESCRIPTION
La till autofocus på textrutan så att man inte behöver klicka på den före man skriver. 

Väldigt banbrytande förändring.